### PR TITLE
Randomize doublet depth size scaling factors

### DIFF
--- a/loner.py
+++ b/loner.py
@@ -43,6 +43,12 @@ def main():
                       cells [Default: %default]')
     parser.add_option('-s', dest='seed',
                       default=None, help='Seed VAE model parameters')
+    parser.add_option('--random_size', dest='randomize_doublet_size',
+                      default=False,
+                      action='store_true',
+                      help='Sample depth multipliers from Unif(1, DoubletDepth) \
+                      to provide a diversity of possible doublet depths.'
+                      )
     (options, args) = parser.parse_args()
 
     if len(args) != 2:
@@ -157,7 +163,11 @@ def main():
         dp /= dp.sum()
 
         # choose depth
-        dd = int(options.doublet_depth * (cell_depths[i] + cell_depths[j]) / 2)
+        if options.randomize_doublet_size:
+            scale_factor = np.random.uniform(1., options.doublet_depth)
+        else:
+            scale_factor = options.doublet_depth
+        dd = int(scale_factor * (cell_depths[i] + cell_depths[j]) / 2)
 
         # sample counts from multinomial
         X_doublets[di, :] = multinomial.rvs(n=dd, p=dp)


### PR DESCRIPTION
Rather than setting a fixed doublet size, add an option to sample the library size of a simulated doublet from a uniform distribution with defined support.

I tried this on some of the muscle data with `s ~ Unif(1, 2)` and to my eye-balling it seems to catch more real doublets. 
Without ground truth though, it's hard to know if this is wishful thinking. 

Maybe worth benchmarking?