### PR TITLE
addressed conda lightning conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ConfigArgParse==1.7
 h5py==3.10.0
 leidenalg==0.10.2
-lightning==2.1.4
+lightning>=2
 lightning-utilities==0.10.1
 numba==0.59.0
 pandas==2.2.1


### PR DESCRIPTION
### Description of your changes
Changed lightning requirements from 2.1.4 to >=2 as it does not conflict with pip installation from requirements.txt and allows for conda/mamba installation

### Issue ticket number and link
Addressed issue #83

### Type of change
- [x] Bug fix

### How has this been tested?

`conda create -n solo python=3.12 && conda activate solo && pip install -e .`
`cd testdata/`
`solo -p -a -g -r 2 --set-reproducible-seed 1 -o results_pbmc_test -j ../solo_params_example.json -d 2c.h5ad`